### PR TITLE
removed unnecessary await on contract creation

### DIFF
--- a/Week2/.vscode/settings.json
+++ b/Week2/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "eslint.format.enable": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": true
+    }
+  }

--- a/Week2/scripts/queryBallotAndGetWinner.ts
+++ b/Week2/scripts/queryBallotAndGetWinner.ts
@@ -8,11 +8,11 @@ async function queryBallotAndGetWinner(
   signer: ethers.Wallet,
   ballotContractAddress: string
 ) {
-  const ballotContract = (await new Contract(
+  const ballotContract = new Contract(
     ballotContractAddress,
     ballotJson.abi,
     signer
-  )) as CustomBallot;
+  ) as CustomBallot;
 
   console.log(`getting winner name`);
   const winnerName = await ballotContract.winnerName();


### PR DESCRIPTION
this addresses the bug: 'reason: 'missing revert data in call exception; Transaction reverted without a reason string''

Removed an unnecessary await when creating the ballot contract.